### PR TITLE
Change Task Update version fact

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,7 +18,7 @@
 
     - name: Update version fact if latest is overridden
       set_fact:
-        jetbrains_toolbox_version: "{{ jetbrains_toolbox_available_releases.json.TBA | sort(attribute='build', reverse=True) | map(attribute='version') | list | first }}"
+        jetbrains_toolbox_version: "{{ jetbrains_toolbox_available_releases.json.TBA | sort(attribute='date', reverse=True) | map(attribute='version') | list | first }}"
       when: jetbrains_toolbox_version == 'latest'
 
     - name: Check if version is valid


### PR DESCRIPTION
Sorting by version doesn't work anymore, 
because the sorting mechanism thinks version 1.9 would be bigger than 1.15. 
If you sort by date it works.