### PR TITLE
Fix latest

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,2 @@
 ---
-# defaults file for jetbrains-toolbox
+jetbrains_toolbox_version: 1.8

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,2 @@
 ---
-jetbrains_toolbox_version: 1.8
+jetbrains_toolbox_version: latest

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,3 +1,1 @@
 ---
-
-jetbrains_toolbox_version: 1.8


### PR DESCRIPTION
Due to [ansible variable precedence](https://docs.ansible.com/ansible/latest/user_guide/playbooks_variables.html#variable-precedence-where-should-i-put-a-variable) this var can't be overridden in a conventional way. Moving it to
defaults will fix this.

Changed the default to be latest since I think that makes the most sane default.